### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -10,7 +10,7 @@ source:
   sha256: d1b6de1c0399e54cbd18321b8091bbffef6d209ec136d4466f398689f62c3b5f
 
 build:
-  number: 1
+  number: 2
   skip: win
 
 requirements:
@@ -36,7 +36,7 @@ requirements:
 
 tests:
   - script:
-      - pixz -h 2>&1 | grep -q "pixz: "\"Parallel Indexing XZ compression, fully compatible with XZ\\\"\""
+      - "pixz -h 2>&1 | grep -q \"pixz: \"\\\"Parallel Indexing XZ compression, fully compatible with XZ\\\\\\\"\\\"\""
 
 about:
   license: BSD-2-Clause


### PR DESCRIPTION
Wrap test script lines containing shell pipes or redirects in quotes. YAML interprets unquoted `|`, `2>&1`, or `:` as special syntax.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
